### PR TITLE
Fix: Add modal handling for password warning in eatTests

### DIFF
--- a/src/test/java/automation/eatTests.java
+++ b/src/test/java/automation/eatTests.java
@@ -2,138 +2,172 @@ package automation;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.annotations.Test;
 import utilities.BaseTest;
 import utilities.Logs;
 
 public class eatTests extends BaseTest {
 
-    @Test
-    public void logintest() {
-        rellenarFormularioLogin("44.444.444-4", "testing");
+        @Test
+        public void logintest() {
+                rellenarFormularioLogin("44.444.444-4", "testing");
 
-        
-        Logs.info("buscando elemento inscripción eat");
-        final var inscripcionEat =
-                driver.findElement(By.xpath("//div[contains(@class, 'cardHome')]//h2[contains(text(), " +
-                        "'Inscripción de la Empresa')]"));
+                Logs.info("buscando elemento inscripción eat");
+                final var inscripcionEat = driver
+                                .findElement(By.xpath("//div[contains(@class, 'cardHome')]//h2[contains(text(), " +
+                                                "'Inscripción de la Empresa')]"));
 
-        Logs.info("click en elemento inscripción eat");
-        inscripcionEat.click();
+                Logs.info("click en elemento inscripción eat");
+                inscripcionEat.click();
 
+                Logs.info("buscando elemento boton ir al tramite");
+                final var botonTramite = driver
+                                .findElement(By.xpath("//button[normalize-space(text())='Ir al trámite']"));
 
-        Logs.info("buscando elemento boton ir al tramite");
-        final var botonTramite =
-                driver.findElement(By.xpath("//button[normalize-space(text())='Ir al trámite']"));
+                Logs.info("click en  elemento BtnIrAlTramite eat");
+                Actions actions = new Actions(driver);
+                actions.moveToElement(botonTramite).click().perform();
 
-        Logs.info("click en  elemento BtnIrAlTramite eat");
-        Actions actions = new Actions(driver);
-        actions.moveToElement(botonTramite).click().perform();
+                sleep(7000);
 
-        sleep(7000);
+                /*
+                 * final var modal = wait.until(
+                 * ExpectedConditions.elementToBeClickable(By.
+                 * xpath("//button[contains(text(), 'Aceptar')]"))
+                 * );
+                 * modal.click();
+                 * 
+                 * 
+                 * 
+                 * 
+                 * final var rutInput =
+                 * driver.findElement(By.cssSelector("input[formcontrolname='rut']"));
+                 * 
+                 * rutInput.sendKeys("18028170-7");
+                 * 
+                 * final var razonSocialInput =
+                 * driver.findElement(By.cssSelector("input[formcontrolname='razonSocial']"));
+                 * 
+                 * razonSocialInput.sendKeys("testing");
+                 * 
+                 */
 
+        }
 
+        @Test
+        public void eattest() {
 
+                final var urlFrontend = "https://pdt-eat-frontend-qa.subtrans.gob.cl/tramites";
 
+                Logs.info("Navegando a : %s", urlFrontend);
+                driver.get(urlFrontend);
 
+                Logs.info("buscando elemento inscripción eat");
+                final var inscripcionEat = driver
+                                .findElement(By.xpath("//div[contains(@class, 'cardHome')]//h2[contains(text(), " +
+                                                "'Inscripción de la Empresa')]"));
 
-        /*final var modal = wait.until(
-                ExpectedConditions.elementToBeClickable(By.xpath("//button[contains(text(), 'Aceptar')]"))
-        );
-        modal.click();
+                Logs.info("click en elemento inscripción eat");
+                inscripcionEat.click();
 
+                Logs.info("buscando elemento clave única");
+                final var claveUnicaBtn = driver.findElement(By.linkText("ClaveÚnica"));
 
+                Actions actions = new Actions(driver);
+                actions.moveToElement(claveUnicaBtn).click().perform();
 
+                Logs.info("Escribiendo Username");
+                final var runInput = driver.findElement(By.id("uname"));
+                runInput.sendKeys("44444444-4");
 
-        final var rutInput =
-                driver.findElement(By.cssSelector("input[formcontrolname='rut']"));
+                Logs.info("Escrbiendo password");
+                final var claveInput = driver.findElement(By.id("pword"));
+                claveInput.sendKeys("testing");
 
-        rutInput.sendKeys("18028170-7");
+                Logs.info("Haciendo click en iniciar sesión");
+                final var loginButton = driver.findElement(By.id("login-submit"));
+                loginButton.click();
 
-        final var razonSocialInput =
-                driver.findElement(By.cssSelector("input[formcontrolname='razonSocial']"));
+                sleep(5000);
 
-        razonSocialInput.sendKeys("testing");
+                // Manejar modal de advertencia de contraseña débil si aparece
+                try {
+                        Logs.info("Verificando si aparece modal de advertencia de contraseña");
+                        final var modalAceptar = wait.until(
+                                        ExpectedConditions.elementToBeClickable(
+                                                        By.xpath("//button[contains(text(), 'Aceptar')]")));
+                        Logs.info("Modal de advertencia encontrado, haciendo click en Aceptar");
+                        modalAceptar.click();
+                        sleep(2000);
+                } catch (Exception e) {
+                        Logs.info("No se encontró modal de advertencia, continuando con el test");
+                }
 
-         */
+                // Continuar con la navegación después del login
+                Logs.info("buscando elemento inscripción eat después del login");
+                final var inscripcionEatPostLogin = driver
+                                .findElement(By.xpath("//div[contains(@class, 'cardHome')]//h2[contains(text(), " +
+                                                "'Inscripción de la Empresa')]"));
 
+                Logs.info("click en elemento inscripción eat después del login");
+                inscripcionEatPostLogin.click();
 
-    }
+                Logs.info("buscando elemento boton ir al tramite");
+                final var botonTramite = driver
+                                .findElement(By.xpath("//button[normalize-space(text())='Ir al trámite']"));
 
-    @Test
-    public void eattest() {
+                Logs.info("click en elemento BtnIrAlTramite eat");
+                Actions actionsPostLogin = new Actions(driver);
+                actionsPostLogin.moveToElement(botonTramite).click().perform();
 
-        final var urlFrontend = "https://pdt-eat-frontend-qa.subtrans.gob.cl/tramites";
+                sleep(7000);
 
-        Logs.info("Navegando a : %s", urlFrontend);
-        driver.get(urlFrontend);
+        }
 
-        Logs.info("buscando elemento inscripción eat");
-        final var inscripcionEat =
-                driver.findElement(By.xpath("//div[contains(@class, 'cardHome')]//h2[contains(text(), " +
-                        "'Inscripción de la Empresa')]"));
+        private void rellenarFormularioLogin(String username, String password) {
 
-        Logs.info("click en elemento inscripción eat");
-        inscripcionEat.click();
+                final var urlFrontend = "https://pdt-eat-frontend-qa.subtrans.gob.cl/tramites";
 
-        Logs.info("buscando elemento clave única");
-        final var claveUnicaBtn =
-                driver.findElement(By.linkText("ClaveÚnica"));
+                Logs.info("Navegando a : %s", urlFrontend);
+                driver.get(urlFrontend);
 
-        Actions actions = new Actions(driver);
-        actions.moveToElement(claveUnicaBtn).click().perform();
+                sleep(3000);
 
-        Logs.info("Escribiendo Username");
-        final var runInput = driver.findElement(By.id("uname"));
-        runInput.sendKeys("44444444-4");
+                Logs.info("buscando elemento clave única");
+                final var claveUnicaBtn = driver.findElement(By.linkText("ClaveÚnica"));
 
-        Logs.info("Escrbiendo password");
-        final var claveInput = driver.findElement(By.id("pword"));
-        claveInput.sendKeys("testing");
+                Actions actions = new Actions(driver);
+                actions.moveToElement(claveUnicaBtn).click().perform();
 
-        Logs.info("Haciendo click en iniciar sesión");
-        final var loginButton = driver.findElement(By.id("login-submit"));
-        loginButton.click();
+                sleep(3000);
 
-        sleep(5000);
+                Logs.info("Escribiendo Username");
+                final var runInput = driver.findElement(By.id("uname"));
+                runInput.sendKeys(username);
 
+                Logs.info("Escrbiendo password");
+                final var claveInput = driver.findElement(By.id("pword"));
+                claveInput.sendKeys(password);
 
-    }
+                Logs.info("Haciendo click en iniciar sesión");
+                final var loginButton = driver.findElement(By.id("login-submit"));
+                loginButton.click();
 
-    private void rellenarFormularioLogin(String username, String password) {
+                sleep(5000);
 
-        final var urlFrontend = "https://pdt-eat-frontend-qa.subtrans.gob.cl/tramites";
+                // Manejar modal de advertencia de contraseña débil si aparece
+                try {
+                        Logs.info("Verificando si aparece modal de advertencia de contraseña en rellenarFormularioLogin");
+                        final var modalAceptar = wait.until(
+                                        ExpectedConditions.elementToBeClickable(
+                                                        By.xpath("//button[contains(text(), 'Aceptar')]")));
+                        Logs.info("Modal de advertencia encontrado en rellenarFormularioLogin, haciendo click en Aceptar");
+                        modalAceptar.click();
+                        sleep(2000);
+                } catch (Exception e) {
+                        Logs.info("No se encontró modal de advertencia en rellenarFormularioLogin, continuando con el test");
+                }
 
-        Logs.info("Navegando a : %s", urlFrontend);
-        driver.get(urlFrontend);
-
-        sleep(3000);
-
-        Logs.info("buscando elemento clave única");
-        final var claveUnicaBtn =
-                driver.findElement(By.linkText("ClaveÚnica"));
-
-        Actions actions = new Actions(driver);
-        actions.moveToElement(claveUnicaBtn).click().perform();
-
-
-        sleep(3000);
-
-
-        Logs.info("Escribiendo Username");
-        final var runInput = driver.findElement(By.id("uname"));
-        runInput.sendKeys(username);
-
-        Logs.info("Escrbiendo password");
-        final var claveInput = driver.findElement(By.id("pword"));
-        claveInput.sendKeys(password);
-
-        Logs.info("Haciendo click en iniciar sesión");
-        final var loginButton = driver.findElement(By.id("login-submit"));
-        loginButton.click();
-
-        sleep(5000);
-
-
-    }
+        }
 }

--- a/src/test/java/utilities/BaseTest.java
+++ b/src/test/java/utilities/BaseTest.java
@@ -13,15 +13,13 @@ import org.testng.asserts.SoftAssert;
 
 import java.time.Duration;
 
-
-@Listeners({TestListeners.class, SuiteListeners.class})
+@Listeners({ TestListeners.class, SuiteListeners.class })
 public class BaseTest {
     protected SoftAssert softAssert;
     protected WebDriver driver;
     protected WebDriverWait wait;
     protected final String regression = "regression";
     protected final String smoke = "smoke";
-
 
     @BeforeMethod(alwaysRun = true)
     public void MastersetUp() {
@@ -40,11 +38,12 @@ public class BaseTest {
         options.addArguments("--disable-popup-blocking");
 
         // Desactiva la gestión automática de contraseñas
-        options.setExperimentalOption("prefs", new java.util.HashMap<String, Object>() {{
-            put("credentials_enable_service", false);
-            put("profile.password_manager_enabled", false);
-        }});
-
+        options.setExperimentalOption("prefs", new java.util.HashMap<String, Object>() {
+            {
+                put("credentials_enable_service", false);
+                put("profile.password_manager_enabled", false);
+            }
+        });
 
         Logs.debug("Inicializando  el drive");
         driver = new ChromeDriver(options);
@@ -58,6 +57,8 @@ public class BaseTest {
         Logs.debug("Seteando implicit wait de 5 segundos");
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
 
+        Logs.debug("Inicializando WebDriverWait");
+        wait = new WebDriverWait(driver, Duration.ofSeconds(10));
 
         Logs.debug("Asignando driver al webdriver provider");
         new WebDriverProvider().set(driver);


### PR DESCRIPTION
- Added ExpectedConditions import to eatTests.java
- Initialized WebDriverWait in BaseTest.java
- Added modal handling logic in eattest() method to handle password warning popup
- Added modal handling logic in rellenarFormularioLogin() method for consistency
- Added complete navigation flow after login in eattest() method
- Tests now handle both scenarios: with and without password warning modal